### PR TITLE
Improve runtime resource discovery

### DIFF
--- a/src/core/App.cpp
+++ b/src/core/App.cpp
@@ -1,19 +1,71 @@
 #include "App.hpp"
 
+#include <cstdlib>
 #include <filesystem>
 #include <iostream>
+#include <stdexcept>
+
+namespace {
+
+std::filesystem::path findProjectRoot() {
+    namespace fs = std::filesystem;
+    auto current = fs::current_path();
+    for (int depth = 0; depth < 10; ++depth) {
+        if (fs::exists(current / "data/settings.json")) {
+            return current;
+        }
+        if (!current.has_parent_path()) {
+            break;
+        }
+        current = current.parent_path();
+    }
+    throw std::runtime_error("TowerDefense project root could not be located. Ensure the data directory is available.");
+}
+
+std::filesystem::path resolveDataPath(const std::filesystem::path& projectRoot) {
+    namespace fs = std::filesystem;
+    if (const char* env = std::getenv("TOWERDEFENSE_DATA")) {
+        fs::path custom(env);
+        if (fs::exists(custom)) {
+            return custom;
+        }
+    }
+    auto dataPath = projectRoot / "data";
+    if (!fs::exists(dataPath)) {
+        throw std::runtime_error("Data directory not found. Expected at: " + dataPath.string());
+    }
+    return dataPath;
+}
+
+std::filesystem::path resolveAssetsPath(const std::filesystem::path& projectRoot) {
+    namespace fs = std::filesystem;
+    if (const char* env = std::getenv("TOWERDEFENSE_ASSETS")) {
+        fs::path custom(env);
+        return custom;
+    }
+    return projectRoot / "assets";
+}
+
+} // namespace
 
 namespace core {
 
 App::App() {
     m_window.create(sf::VideoMode(1280, 720), "TowerDefense", sf::Style::Default);
     m_window.setFramerateLimit(60);
-    std::filesystem::create_directory("data");
-    m_resources.loadTexture("tiles", "assets/textures/placeholder.png");
-    m_resources.loadTexture("ui", "assets/textures/placeholder.png");
-    m_resources.loadSound("click", "assets/audio/placeholder.wav");
-    m_resources.loadFont("default", "assets/fonts/DejaVuSans.ttf");
-    m_database = m_loader.loadAll("data");
+    m_projectRoot = findProjectRoot();
+    m_dataPath = resolveDataPath(m_projectRoot);
+    m_assetsPath = resolveAssetsPath(m_projectRoot);
+    if (!std::filesystem::exists(m_assetsPath)) {
+        std::cerr << "[App] Asset directory could not be found at '" << m_assetsPath
+                  << "'. Procedural placeholders will be used.\n";
+    }
+    m_resources.setAssetRoot(m_assetsPath);
+    m_resources.loadTexture("tiles", "textures/placeholder.png");
+    m_resources.loadTexture("ui", "textures/placeholder.png");
+    m_resources.loadSound("click", "audio/placeholder.wav");
+    m_resources.loadFont("default", "fonts/DejaVuSans.ttf");
+    m_database = m_loader.loadAll(m_dataPath.string());
     m_game = std::make_unique<Game>(m_resources, m_database);
 }
 

--- a/src/core/App.hpp
+++ b/src/core/App.hpp
@@ -5,6 +5,7 @@
 #include "ResourceManager.hpp"
 #include "TimeStep.hpp"
 #include <SFML/Graphics.hpp>
+#include <filesystem>
 #include <memory>
 
 namespace core {
@@ -25,6 +26,9 @@ private:
     data::GameDatabase m_database;
     std::unique_ptr<core::Game> m_game;
     core::TimeStep m_time;
+    std::filesystem::path m_projectRoot;
+    std::filesystem::path m_dataPath;
+    std::filesystem::path m_assetsPath;
 };
 
 } // namespace core

--- a/src/core/ResourceManager.cpp
+++ b/src/core/ResourceManager.cpp
@@ -1,0 +1,150 @@
+#include "ResourceManager.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+namespace core {
+
+namespace {
+constexpr unsigned int kGeneratedTextureSize = 64;
+constexpr unsigned int kSilentSampleRate = 22050;
+constexpr unsigned int kSilentDurationMs = 250;
+} // namespace
+
+void ResourceManager::setAssetRoot(std::filesystem::path root) {
+    m_assetRoot = std::move(root);
+}
+
+std::filesystem::path ResourceManager::resolvePath(const std::filesystem::path& path) const {
+    if (path.empty()) {
+        return {};
+    }
+    if (path.is_absolute() || m_assetRoot.empty()) {
+        return path;
+    }
+    return m_assetRoot / path;
+}
+
+void ResourceManager::generatePlaceholderTexture(sf::Texture& texture) const {
+    sf::Image image;
+    image.create(kGeneratedTextureSize, kGeneratedTextureSize, sf::Color(160, 160, 160));
+    for (unsigned int y = 0; y < kGeneratedTextureSize; ++y) {
+        for (unsigned int x = 0; x < kGeneratedTextureSize; ++x) {
+            if ((x / 8 + y / 8) % 2 == 0) {
+                image.setPixel(x, y, sf::Color(110, 110, 110));
+            }
+        }
+    }
+    if (!texture.loadFromImage(image)) {
+        throw std::runtime_error("Failed to create procedural placeholder texture");
+    }
+    texture.setSmooth(false);
+}
+
+void ResourceManager::generateSilentSound(sf::SoundBuffer& buffer) const {
+    const unsigned int sampleCount = kSilentSampleRate * kSilentDurationMs / 1000;
+    std::vector<sf::Int16> samples(sampleCount, 0);
+    if (!buffer.loadFromSamples(samples.data(), samples.size(), 1, kSilentSampleRate)) {
+        throw std::runtime_error("Failed to create procedural silent sound");
+    }
+}
+
+bool ResourceManager::loadTexture(const std::string& id, const std::filesystem::path& path) {
+    auto texture = std::make_unique<sf::Texture>();
+    const auto resolved = resolvePath(path);
+    bool loadedFromFile = false;
+    if (!resolved.empty()) {
+        std::error_code ec;
+        if (std::filesystem::exists(resolved, ec)) {
+            loadedFromFile = texture->loadFromFile(resolved.string());
+        }
+    }
+    if (!loadedFromFile) {
+        generatePlaceholderTexture(*texture);
+        std::cerr << "[ResourceManager] Using generated texture for '" << id << "' (missing file: " << resolved
+                  << ")\n";
+    } else {
+        texture->setSmooth(true);
+    }
+    m_textures[id] = std::move(texture);
+    return loadedFromFile;
+}
+
+bool ResourceManager::loadSound(const std::string& id, const std::filesystem::path& path) {
+    auto buffer = std::make_unique<sf::SoundBuffer>();
+    const auto resolved = resolvePath(path);
+    bool loadedFromFile = false;
+    if (!resolved.empty()) {
+        std::error_code ec;
+        if (std::filesystem::exists(resolved, ec)) {
+            loadedFromFile = buffer->loadFromFile(resolved.string());
+        }
+    }
+    if (!loadedFromFile) {
+        generateSilentSound(*buffer);
+        std::cerr << "[ResourceManager] Using generated silent sound for '" << id << "' (missing file: " << resolved
+                  << ")\n";
+    }
+    m_sounds[id] = std::move(buffer);
+    return loadedFromFile;
+}
+
+bool ResourceManager::tryLoadFont(sf::Font& font, const std::filesystem::path& path) const {
+    if (path.empty()) {
+        return false;
+    }
+    std::error_code ec;
+    if (!std::filesystem::exists(path, ec)) {
+        return false;
+    }
+    return font.loadFromFile(path.string());
+}
+
+std::vector<std::filesystem::path> ResourceManager::fontFallbackCandidates() const {
+    std::vector<std::filesystem::path> candidates;
+    if (!m_assetRoot.empty()) {
+        candidates.push_back(m_assetRoot / "fonts/DejaVuSans.ttf");
+    }
+    if (const char* env = std::getenv("TOWERDEFENSE_FONT")) {
+        candidates.emplace_back(env);
+    }
+#ifdef _WIN32
+    if (const char* windir = std::getenv("WINDIR")) {
+        std::filesystem::path base(windir);
+        candidates.push_back(base / "Fonts/arial.ttf");
+        candidates.push_back(base / "Fonts/segoeui.ttf");
+    }
+    candidates.emplace_back("C:/Windows/Fonts/arial.ttf");
+    candidates.emplace_back("C:/Windows/Fonts/segoeui.ttf");
+#elif __APPLE__
+    candidates.emplace_back("/System/Library/Fonts/Supplemental/Helvetica.ttf");
+    candidates.emplace_back("/System/Library/Fonts/Supplemental/Arial Unicode.ttf");
+#else
+    candidates.emplace_back("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf");
+    candidates.emplace_back("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf");
+    candidates.emplace_back("/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf");
+    candidates.emplace_back("/usr/share/fonts/truetype/freefont/FreeSans.ttf");
+#endif
+    return candidates;
+}
+
+bool ResourceManager::loadFont(const std::string& id, const std::filesystem::path& path) {
+    auto font = std::make_unique<sf::Font>();
+    const auto resolved = resolvePath(path);
+    if (tryLoadFont(*font, resolved)) {
+        m_fonts[id] = std::move(font);
+        return true;
+    }
+    for (const auto& candidate : fontFallbackCandidates()) {
+        if (tryLoadFont(*font, candidate)) {
+            std::cerr << "[ResourceManager] Loaded font '" << id << "' from fallback: " << candidate << "\n";
+            m_fonts[id] = std::move(font);
+            return true;
+        }
+    }
+    throw std::runtime_error("Failed to load font '" + id + "' from '" + resolved.string() + "' or fallbacks");
+}
+
+} // namespace core

--- a/src/core/ResourceManager.hpp
+++ b/src/core/ResourceManager.hpp
@@ -2,41 +2,21 @@
 
 #include <SFML/Audio.hpp>
 #include <SFML/Graphics.hpp>
+#include <filesystem>
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace core {
 
 class ResourceManager {
 public:
-    bool loadTexture(const std::string& id, const std::string& path) {
-        auto texture = std::make_unique<sf::Texture>();
-        if (!texture->loadFromFile(path)) {
-            return false;
-        }
-        texture->setSmooth(true);
-        m_textures[id] = std::move(texture);
-        return true;
-    }
+    void setAssetRoot(std::filesystem::path root);
 
-    bool loadSound(const std::string& id, const std::string& path) {
-        auto buffer = std::make_unique<sf::SoundBuffer>();
-        if (!buffer->loadFromFile(path)) {
-            return false;
-        }
-        m_sounds[id] = std::move(buffer);
-        return true;
-    }
-
-    bool loadFont(const std::string& id, const std::string& path) {
-        auto font = std::make_unique<sf::Font>();
-        if (!font->loadFromFile(path)) {
-            return false;
-        }
-        m_fonts[id] = std::move(font);
-        return true;
-    }
+    bool loadTexture(const std::string& id, const std::filesystem::path& path);
+    bool loadSound(const std::string& id, const std::filesystem::path& path);
+    bool loadFont(const std::string& id, const std::filesystem::path& path);
 
     sf::Texture& texture(const std::string& id) { return *m_textures.at(id); }
     const sf::Texture& texture(const std::string& id) const { return *m_textures.at(id); }
@@ -48,6 +28,13 @@ public:
     const sf::Font& font(const std::string& id) const { return *m_fonts.at(id); }
 
 private:
+    std::filesystem::path resolvePath(const std::filesystem::path& path) const;
+    bool tryLoadFont(sf::Font& font, const std::filesystem::path& path) const;
+    std::vector<std::filesystem::path> fontFallbackCandidates() const;
+    void generatePlaceholderTexture(sf::Texture& texture) const;
+    void generateSilentSound(sf::SoundBuffer& buffer) const;
+
+    std::filesystem::path m_assetRoot;
     std::map<std::string, std::unique_ptr<sf::Texture>> m_textures;
     std::map<std::string, std::unique_ptr<sf::SoundBuffer>> m_sounds;
     std::map<std::string, std::unique_ptr<sf::Font>> m_fonts;


### PR DESCRIPTION
## Summary
- locate the project root at startup so data files can be loaded when the executable runs from a CMake build directory
- allow overriding data and asset locations via environment variables and warn when the asset folder is missing
- extend the resource manager with generated placeholders and system font fallbacks so the game can still run without bundled binary assets

## Testing
- `cmake -S . -B build` *(fails: blocked from downloading SFML 2.6.0 by proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cf262f194c8326a23730b455cb6f2b