### PR TITLE
Fix JSON helpers and handle repeated SFML patching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,16 +7,62 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 include(FetchContent)
 
+find_program(PATCH_EXECUTABLE patch)
+if (NOT PATCH_EXECUTABLE)
+    message(FATAL_ERROR "Required tool 'patch' was not found. Please install a POSIX patch utility.")
+endif()
+
 set(SFML_BUILD_AUDIO ON CACHE BOOL "" FORCE)
 set(SFML_BUILD_GRAPHICS ON CACHE BOOL "" FORCE)
 set(SFML_BUILD_WINDOW ON CACHE BOOL "" FORCE)
 set(SFML_BUILD_NETWORK OFF CACHE BOOL "" FORCE)
 set(SFML_BUILD_SYSTEM ON CACHE BOOL "" FORCE)
+
+set(SFML_PATCH_FILE "${CMAKE_SOURCE_DIR}/cmake/patches/sfml-libcxx-char-traits.patch")
+
 FetchContent_Declare(
     sfml
     URL https://github.com/SFML/SFML/archive/refs/tags/2.6.0.tar.gz
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
 )
-FetchContent_MakeAvailable(sfml)
+
+FetchContent_GetProperties(sfml)
+if (NOT sfml_POPULATED)
+    FetchContent_Populate(sfml)
+
+    execute_process(
+        COMMAND ${PATCH_EXECUTABLE} -p1 --dry-run -R -i "${SFML_PATCH_FILE}"
+        WORKING_DIRECTORY ${sfml_SOURCE_DIR}
+        RESULT_VARIABLE SFML_PATCH_ALREADY_APPLIED
+        OUTPUT_VARIABLE SFML_PATCH_REVERSE_OUTPUT
+        ERROR_VARIABLE SFML_PATCH_REVERSE_ERROR
+    )
+
+    if (SFML_PATCH_ALREADY_APPLIED EQUAL 0)
+        message(STATUS "SFML libc++ compatibility patch already applied; skipping.")
+    else()
+        execute_process(
+            COMMAND ${PATCH_EXECUTABLE} -p1 -i "${SFML_PATCH_FILE}"
+            WORKING_DIRECTORY ${sfml_SOURCE_DIR}
+            RESULT_VARIABLE SFML_PATCH_RESULT
+            OUTPUT_VARIABLE SFML_PATCH_OUTPUT
+            ERROR_VARIABLE SFML_PATCH_ERROR
+        )
+
+        if (NOT SFML_PATCH_RESULT EQUAL 0)
+            string(JOIN "\n" _sfml_patch_message
+                "Failed to apply SFML libc++ compatibility patch."
+                "Command: ${PATCH_EXECUTABLE} -p1 -i \"${SFML_PATCH_FILE}\""
+                "Working directory: ${sfml_SOURCE_DIR}"
+                "stdout: ${SFML_PATCH_OUTPUT}"
+                "stderr: ${SFML_PATCH_ERROR}"
+            )
+            message(FATAL_ERROR "${_sfml_patch_message}")
+        endif()
+    endif()
+endif()
+
+add_subdirectory(${sfml_SOURCE_DIR} ${sfml_BINARY_DIR})
 
 file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS src/*.cpp)
 

--- a/cmake/patches/sfml-libcxx-char-traits.patch
+++ b/cmake/patches/sfml-libcxx-char-traits.patch
@@ -1,0 +1,218 @@
+--- a/include/SFML/System/String.hpp
++++ b/include/SFML/System/String.hpp
+@@ -28,12 +28,215 @@
+ ////////////////////////////////////////////////////////////
+ // Headers
+ ////////////////////////////////////////////////////////////
++#include <SFML/Config.hpp>
+ #include <SFML/System/Export.hpp>
+ #include <SFML/System/Utf.hpp>
+ #include <iterator>
+ #include <locale>
+ #include <string>
+ 
++#if defined(_LIBCPP_VERSION)
++#include <compare>
++#include <cstddef>
++#include <cstdint>
++#include <cstring>
++#include <cwchar>
++#include <ios>
++#include <istream>
++
++namespace std
++{
++template <>
++struct char_traits<sf::Uint8>
++{
++    using char_type = sf::Uint8;
++    using int_type = int;
++    using off_type = std::streamoff;
++    using pos_type = std::streampos;
++    using state_type = std::mbstate_t;
++    using comparison_category = std::strong_ordering;
++
++    static void assign(char_type& r, const char_type& a) noexcept { r = a; }
++    static constexpr bool eq(char_type c1, char_type c2) noexcept { return c1 == c2; }
++    static constexpr bool lt(char_type c1, char_type c2) noexcept { return c1 < c2; }
++    static int compare(const char_type* s1, const char_type* s2, std::size_t n) noexcept
++    {
++        for (std::size_t i = 0; i < n; ++i)
++        {
++            if (lt(s1[i], s2[i]))
++                return -1;
++            if (lt(s2[i], s1[i]))
++                return 1;
++        }
++        return 0;
++    }
++    static std::size_t length(const char_type* s) noexcept
++    {
++        std::size_t len = 0;
++        while (!eq(s[len], char_type()))
++            ++len;
++        return len;
++    }
++    static const char_type* find(const char_type* s, std::size_t n, const char_type& a) noexcept
++    {
++        for (std::size_t i = 0; i < n; ++i)
++            if (eq(s[i], a))
++                return s + i;
++        return nullptr;
++    }
++    static char_type* move(char_type* s1, const char_type* s2, std::size_t n) noexcept
++    {
++        if (s1 == s2)
++            return s1;
++        std::memmove(s1, s2, n * sizeof(char_type));
++        return s1;
++    }
++    static char_type* copy(char_type* s1, const char_type* s2, std::size_t n) noexcept
++    {
++        std::memcpy(s1, s2, n * sizeof(char_type));
++        return s1;
++    }
++    static char_type* assign(char_type* s, std::size_t n, char_type a) noexcept
++    {
++        for (std::size_t i = 0; i < n; ++i)
++            s[i] = a;
++        return s;
++    }
++    static constexpr char_type to_char_type(int_type c) noexcept { return static_cast<char_type>(c); }
++    static constexpr int_type to_int_type(char_type c) noexcept { return static_cast<int_type>(c); }
++    static constexpr bool eq_int_type(int_type c1, int_type c2) noexcept { return c1 == c2; }
++    static constexpr int_type eof() noexcept { return -1; }
++    static constexpr int_type not_eof(int_type c) noexcept { return eq_int_type(c, eof()) ? 0 : c; }
++};
++
++template <>
++struct char_traits<sf::Uint16>
++{
++    using char_type = sf::Uint16;
++    using int_type = std::uint_least32_t;
++    using off_type = std::streamoff;
++    using pos_type = std::u16streampos;
++    using state_type = std::mbstate_t;
++    using comparison_category = std::strong_ordering;
++
++    static void assign(char_type& r, const char_type& a) noexcept { r = a; }
++    static constexpr bool eq(char_type c1, char_type c2) noexcept { return c1 == c2; }
++    static constexpr bool lt(char_type c1, char_type c2) noexcept { return c1 < c2; }
++    static int compare(const char_type* s1, const char_type* s2, std::size_t n) noexcept
++    {
++        for (std::size_t i = 0; i < n; ++i)
++        {
++            if (lt(s1[i], s2[i]))
++                return -1;
++            if (lt(s2[i], s1[i]))
++                return 1;
++        }
++        return 0;
++    }
++    static std::size_t length(const char_type* s) noexcept
++    {
++        std::size_t len = 0;
++        while (!eq(s[len], char_type()))
++            ++len;
++        return len;
++    }
++    static const char_type* find(const char_type* s, std::size_t n, const char_type& a) noexcept
++    {
++        for (std::size_t i = 0; i < n; ++i)
++            if (eq(s[i], a))
++                return s + i;
++        return nullptr;
++    }
++    static char_type* move(char_type* s1, const char_type* s2, std::size_t n) noexcept
++    {
++        if (s1 == s2)
++            return s1;
++        std::memmove(s1, s2, n * sizeof(char_type));
++        return s1;
++    }
++    static char_type* copy(char_type* s1, const char_type* s2, std::size_t n) noexcept
++    {
++        std::memcpy(s1, s2, n * sizeof(char_type));
++        return s1;
++    }
++    static char_type* assign(char_type* s, std::size_t n, char_type a) noexcept
++    {
++        for (std::size_t i = 0; i < n; ++i)
++            s[i] = a;
++        return s;
++    }
++    static constexpr char_type to_char_type(int_type c) noexcept { return static_cast<char_type>(c); }
++    static constexpr int_type to_int_type(char_type c) noexcept { return static_cast<int_type>(c); }
++    static constexpr bool eq_int_type(int_type c1, int_type c2) noexcept { return c1 == c2; }
++    static constexpr int_type eof() noexcept { return static_cast<int_type>(-1); }
++    static constexpr int_type not_eof(int_type c) noexcept { return eq_int_type(c, eof()) ? static_cast<int_type>(0) : c; }
++};
++
++template <>
++struct char_traits<sf::Uint32>
++{
++    using char_type = sf::Uint32;
++    using int_type = std::uint_least32_t;
++    using off_type = std::streamoff;
++    using pos_type = std::u32streampos;
++    using state_type = std::mbstate_t;
++    using comparison_category = std::strong_ordering;
++
++    static void assign(char_type& r, const char_type& a) noexcept { r = a; }
++    static constexpr bool eq(char_type c1, char_type c2) noexcept { return c1 == c2; }
++    static constexpr bool lt(char_type c1, char_type c2) noexcept { return c1 < c2; }
++    static int compare(const char_type* s1, const char_type* s2, std::size_t n) noexcept
++    {
++        for (std::size_t i = 0; i < n; ++i)
++        {
++            if (lt(s1[i], s2[i]))
++                return -1;
++            if (lt(s2[i], s1[i]))
++                return 1;
++        }
++        return 0;
++    }
++    static std::size_t length(const char_type* s) noexcept
++    {
++        std::size_t len = 0;
++        while (!eq(s[len], char_type()))
++            ++len;
++        return len;
++    }
++    static const char_type* find(const char_type* s, std::size_t n, const char_type& a) noexcept
++    {
++        for (std::size_t i = 0; i < n; ++i)
++            if (eq(s[i], a))
++                return s + i;
++        return nullptr;
++    }
++    static char_type* move(char_type* s1, const char_type* s2, std::size_t n) noexcept
++    {
++        if (s1 == s2)
++            return s1;
++        std::memmove(s1, s2, n * sizeof(char_type));
++        return s1;
++    }
++    static char_type* copy(char_type* s1, const char_type* s2, std::size_t n) noexcept
++    {
++        std::memcpy(s1, s2, n * sizeof(char_type));
++        return s1;
++    }
++    static char_type* assign(char_type* s, std::size_t n, char_type a) noexcept
++    {
++        for (std::size_t i = 0; i < n; ++i)
++            s[i] = a;
++        return s;
++    }
++    static constexpr char_type to_char_type(int_type c) noexcept { return static_cast<char_type>(c); }
++    static constexpr int_type to_int_type(char_type c) noexcept { return static_cast<int_type>(c); }
++    static constexpr bool eq_int_type(int_type c1, int_type c2) noexcept { return c1 == c2; }
++    static constexpr int_type eof() noexcept { return static_cast<int_type>(-1); }
++    static constexpr int_type not_eof(int_type c) noexcept { return eq_int_type(c, eof()) ? static_cast<int_type>(0) : c; }
++};
++} // namespace std
++#endif
++
+ 
+ namespace sf
+ {

--- a/src/core/App.cpp
+++ b/src/core/App.cpp
@@ -1,19 +1,71 @@
 #include "App.hpp"
 
+#include <cstdlib>
 #include <filesystem>
 #include <iostream>
+#include <stdexcept>
+
+namespace {
+
+std::filesystem::path findProjectRoot() {
+    namespace fs = std::filesystem;
+    auto current = fs::current_path();
+    for (int depth = 0; depth < 10; ++depth) {
+        if (fs::exists(current / "data/settings.json")) {
+            return current;
+        }
+        if (!current.has_parent_path()) {
+            break;
+        }
+        current = current.parent_path();
+    }
+    throw std::runtime_error("TowerDefense project root could not be located. Ensure the data directory is available.");
+}
+
+std::filesystem::path resolveDataPath(const std::filesystem::path& projectRoot) {
+    namespace fs = std::filesystem;
+    if (const char* env = std::getenv("TOWERDEFENSE_DATA")) {
+        fs::path custom(env);
+        if (fs::exists(custom)) {
+            return custom;
+        }
+    }
+    auto dataPath = projectRoot / "data";
+    if (!fs::exists(dataPath)) {
+        throw std::runtime_error("Data directory not found. Expected at: " + dataPath.string());
+    }
+    return dataPath;
+}
+
+std::filesystem::path resolveAssetsPath(const std::filesystem::path& projectRoot) {
+    namespace fs = std::filesystem;
+    if (const char* env = std::getenv("TOWERDEFENSE_ASSETS")) {
+        fs::path custom(env);
+        return custom;
+    }
+    return projectRoot / "assets";
+}
+
+} // namespace
 
 namespace core {
 
 App::App() {
     m_window.create(sf::VideoMode(1280, 720), "TowerDefense", sf::Style::Default);
     m_window.setFramerateLimit(60);
-    std::filesystem::create_directory("data");
-    m_resources.loadTexture("tiles", "assets/textures/placeholder.png");
-    m_resources.loadTexture("ui", "assets/textures/placeholder.png");
-    m_resources.loadSound("click", "assets/audio/placeholder.wav");
-    m_resources.loadFont("default", "assets/fonts/DejaVuSans.ttf");
-    m_database = m_loader.loadAll("data");
+    m_projectRoot = findProjectRoot();
+    m_dataPath = resolveDataPath(m_projectRoot);
+    m_assetsPath = resolveAssetsPath(m_projectRoot);
+    if (!std::filesystem::exists(m_assetsPath)) {
+        std::cerr << "[App] Asset directory could not be found at '" << m_assetsPath
+                  << "'. Procedural placeholders will be used.\n";
+    }
+    m_resources.setAssetRoot(m_assetsPath);
+    m_resources.loadTexture("tiles", "textures/placeholder.png");
+    m_resources.loadTexture("ui", "textures/placeholder.png");
+    m_resources.loadSound("click", "audio/placeholder.wav");
+    m_resources.loadFont("default", "fonts/DejaVuSans.ttf");
+    m_database = m_loader.loadAll(m_dataPath.string());
     m_game = std::make_unique<Game>(m_resources, m_database);
 }
 

--- a/src/core/App.hpp
+++ b/src/core/App.hpp
@@ -5,6 +5,7 @@
 #include "ResourceManager.hpp"
 #include "TimeStep.hpp"
 #include <SFML/Graphics.hpp>
+#include <filesystem>
 #include <memory>
 
 namespace core {
@@ -25,6 +26,9 @@ private:
     data::GameDatabase m_database;
     std::unique_ptr<core::Game> m_game;
     core::TimeStep m_time;
+    std::filesystem::path m_projectRoot;
+    std::filesystem::path m_dataPath;
+    std::filesystem::path m_assetsPath;
 };
 
 } // namespace core

--- a/src/core/DataLoader.cpp
+++ b/src/core/DataLoader.cpp
@@ -1,6 +1,7 @@
 #include "DataLoader.hpp"
 
 #include <SFML/System/Vector2.hpp>
+#include <SFML/System/Vector3.hpp>
 #include <fstream>
 #include <iostream>
 #include <nlohmann/json.hpp>
@@ -246,24 +247,22 @@ data::GameDatabase DataLoader::loadAll(const std::string& dataPath) {
 }
 
 void DataLoader::saveSettings(const std::string& path, const data::SettingsData& settings) {
-    nlohmann::json j;
-    j["audioVolume"] = settings.audioVolume;
-    j["musicVolume"] = settings.musicVolume;
-    j["gameSpeed"] = settings.gameSpeed;
-    j["graphicsQuality"] = settings.graphicsQuality;
-    j["colorBlindMode"] = settings.colorBlindMode;
+    const nlohmann::json j{{"audioVolume", settings.audioVolume},
+                           {"musicVolume", settings.musicVolume},
+                           {"gameSpeed", settings.gameSpeed},
+                           {"graphicsQuality", settings.graphicsQuality},
+                           {"colorBlindMode", settings.colorBlindMode}};
 
     std::ofstream file(path);
     file << j.dump(2);
 }
 
 void DataLoader::saveProgress(const std::string& path, const data::SaveData& save) {
-    nlohmann::json j;
-    j["lastUnlockedLevel"] = save.lastUnlockedLevel;
-    j["coins"] = save.coins;
-    j["badges"] = save.badges;
-    j["unlockedTowers"] = save.unlockedTowers;
-    j["completedLevels"] = save.completedLevels;
+    const nlohmann::json j{{"lastUnlockedLevel", save.lastUnlockedLevel},
+                           {"coins", save.coins},
+                           {"badges", save.badges},
+                           {"unlockedTowers", save.unlockedTowers},
+                           {"completedLevels", save.completedLevels}};
 
     std::ofstream file(path);
     file << j.dump(2);

--- a/src/core/Game.cpp
+++ b/src/core/Game.cpp
@@ -109,7 +109,7 @@ void Game::handleEvent(const sf::Event& event, const sf::Vector2f& mouseWorld) {
 
 void Game::update(float dt) {
     if (m_state == GameState::Gameplay && !m_paused) {
-        float speedMultiplier = static_cast<int>(m_speed);
+        const float speedMultiplier = static_cast<float>(m_speed);
         dt *= speedMultiplier;
         updateEconomy(dt);
         int livesLost = 0;
@@ -146,7 +146,9 @@ void Game::update(float dt) {
         } else if (m_waveInProgress && m_registry.m_enemyStats.empty()) {
             m_waveInProgress = false;
             m_coins += static_cast<int>(m_database.balance.waveClearBonus);
-            if (m_waveIndex >= static_cast<int>(m_database.waves[m_currentLevelId].waves.size())) {
+            if (const auto waveDataIt = m_database.waves.find(m_currentLevelId);
+                waveDataIt != m_database.waves.end() &&
+                m_waveIndex >= static_cast<int>(waveDataIt->second.waves.size())) {
                 m_state = GameState::Victory;
             }
         }

--- a/src/core/GameData.hpp
+++ b/src/core/GameData.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <SFML/System/Vector2.hpp>
+#include <SFML/System/Vector3.hpp>
 #include <map>
 #include <set>
 #include <string>

--- a/src/core/ResourceManager.cpp
+++ b/src/core/ResourceManager.cpp
@@ -1,0 +1,150 @@
+#include "ResourceManager.hpp"
+
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+namespace core {
+
+namespace {
+constexpr unsigned int kGeneratedTextureSize = 64;
+constexpr unsigned int kSilentSampleRate = 22050;
+constexpr unsigned int kSilentDurationMs = 250;
+} // namespace
+
+void ResourceManager::setAssetRoot(std::filesystem::path root) {
+    m_assetRoot = std::move(root);
+}
+
+std::filesystem::path ResourceManager::resolvePath(const std::filesystem::path& path) const {
+    if (path.empty()) {
+        return {};
+    }
+    if (path.is_absolute() || m_assetRoot.empty()) {
+        return path;
+    }
+    return m_assetRoot / path;
+}
+
+void ResourceManager::generatePlaceholderTexture(sf::Texture& texture) const {
+    sf::Image image;
+    image.create(kGeneratedTextureSize, kGeneratedTextureSize, sf::Color(160, 160, 160));
+    for (unsigned int y = 0; y < kGeneratedTextureSize; ++y) {
+        for (unsigned int x = 0; x < kGeneratedTextureSize; ++x) {
+            if ((x / 8 + y / 8) % 2 == 0) {
+                image.setPixel(x, y, sf::Color(110, 110, 110));
+            }
+        }
+    }
+    if (!texture.loadFromImage(image)) {
+        throw std::runtime_error("Failed to create procedural placeholder texture");
+    }
+    texture.setSmooth(false);
+}
+
+void ResourceManager::generateSilentSound(sf::SoundBuffer& buffer) const {
+    const unsigned int sampleCount = kSilentSampleRate * kSilentDurationMs / 1000;
+    std::vector<sf::Int16> samples(sampleCount, 0);
+    if (!buffer.loadFromSamples(samples.data(), samples.size(), 1, kSilentSampleRate)) {
+        throw std::runtime_error("Failed to create procedural silent sound");
+    }
+}
+
+bool ResourceManager::loadTexture(const std::string& id, const std::filesystem::path& path) {
+    auto texture = std::make_unique<sf::Texture>();
+    const auto resolved = resolvePath(path);
+    bool loadedFromFile = false;
+    if (!resolved.empty()) {
+        std::error_code ec;
+        if (std::filesystem::exists(resolved, ec)) {
+            loadedFromFile = texture->loadFromFile(resolved.string());
+        }
+    }
+    if (!loadedFromFile) {
+        generatePlaceholderTexture(*texture);
+        std::cerr << "[ResourceManager] Using generated texture for '" << id << "' (missing file: " << resolved
+                  << ")\n";
+    } else {
+        texture->setSmooth(true);
+    }
+    m_textures[id] = std::move(texture);
+    return loadedFromFile;
+}
+
+bool ResourceManager::loadSound(const std::string& id, const std::filesystem::path& path) {
+    auto buffer = std::make_unique<sf::SoundBuffer>();
+    const auto resolved = resolvePath(path);
+    bool loadedFromFile = false;
+    if (!resolved.empty()) {
+        std::error_code ec;
+        if (std::filesystem::exists(resolved, ec)) {
+            loadedFromFile = buffer->loadFromFile(resolved.string());
+        }
+    }
+    if (!loadedFromFile) {
+        generateSilentSound(*buffer);
+        std::cerr << "[ResourceManager] Using generated silent sound for '" << id << "' (missing file: " << resolved
+                  << ")\n";
+    }
+    m_sounds[id] = std::move(buffer);
+    return loadedFromFile;
+}
+
+bool ResourceManager::tryLoadFont(sf::Font& font, const std::filesystem::path& path) const {
+    if (path.empty()) {
+        return false;
+    }
+    std::error_code ec;
+    if (!std::filesystem::exists(path, ec)) {
+        return false;
+    }
+    return font.loadFromFile(path.string());
+}
+
+std::vector<std::filesystem::path> ResourceManager::fontFallbackCandidates() const {
+    std::vector<std::filesystem::path> candidates;
+    if (!m_assetRoot.empty()) {
+        candidates.push_back(m_assetRoot / "fonts/DejaVuSans.ttf");
+    }
+    if (const char* env = std::getenv("TOWERDEFENSE_FONT")) {
+        candidates.emplace_back(env);
+    }
+#ifdef _WIN32
+    if (const char* windir = std::getenv("WINDIR")) {
+        std::filesystem::path base(windir);
+        candidates.push_back(base / "Fonts/arial.ttf");
+        candidates.push_back(base / "Fonts/segoeui.ttf");
+    }
+    candidates.emplace_back("C:/Windows/Fonts/arial.ttf");
+    candidates.emplace_back("C:/Windows/Fonts/segoeui.ttf");
+#elif __APPLE__
+    candidates.emplace_back("/System/Library/Fonts/Supplemental/Helvetica.ttf");
+    candidates.emplace_back("/System/Library/Fonts/Supplemental/Arial Unicode.ttf");
+#else
+    candidates.emplace_back("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf");
+    candidates.emplace_back("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf");
+    candidates.emplace_back("/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf");
+    candidates.emplace_back("/usr/share/fonts/truetype/freefont/FreeSans.ttf");
+#endif
+    return candidates;
+}
+
+bool ResourceManager::loadFont(const std::string& id, const std::filesystem::path& path) {
+    auto font = std::make_unique<sf::Font>();
+    const auto resolved = resolvePath(path);
+    if (tryLoadFont(*font, resolved)) {
+        m_fonts[id] = std::move(font);
+        return true;
+    }
+    for (const auto& candidate : fontFallbackCandidates()) {
+        if (tryLoadFont(*font, candidate)) {
+            std::cerr << "[ResourceManager] Loaded font '" << id << "' from fallback: " << candidate << "\n";
+            m_fonts[id] = std::move(font);
+            return true;
+        }
+    }
+    throw std::runtime_error("Failed to load font '" + id + "' from '" + resolved.string() + "' or fallbacks");
+}
+
+} // namespace core

--- a/src/core/ResourceManager.hpp
+++ b/src/core/ResourceManager.hpp
@@ -2,41 +2,21 @@
 
 #include <SFML/Audio.hpp>
 #include <SFML/Graphics.hpp>
+#include <filesystem>
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace core {
 
 class ResourceManager {
 public:
-    bool loadTexture(const std::string& id, const std::string& path) {
-        auto texture = std::make_unique<sf::Texture>();
-        if (!texture->loadFromFile(path)) {
-            return false;
-        }
-        texture->setSmooth(true);
-        m_textures[id] = std::move(texture);
-        return true;
-    }
+    void setAssetRoot(std::filesystem::path root);
 
-    bool loadSound(const std::string& id, const std::string& path) {
-        auto buffer = std::make_unique<sf::SoundBuffer>();
-        if (!buffer->loadFromFile(path)) {
-            return false;
-        }
-        m_sounds[id] = std::move(buffer);
-        return true;
-    }
-
-    bool loadFont(const std::string& id, const std::string& path) {
-        auto font = std::make_unique<sf::Font>();
-        if (!font->loadFromFile(path)) {
-            return false;
-        }
-        m_fonts[id] = std::move(font);
-        return true;
-    }
+    bool loadTexture(const std::string& id, const std::filesystem::path& path);
+    bool loadSound(const std::string& id, const std::filesystem::path& path);
+    bool loadFont(const std::string& id, const std::filesystem::path& path);
 
     sf::Texture& texture(const std::string& id) { return *m_textures.at(id); }
     const sf::Texture& texture(const std::string& id) const { return *m_textures.at(id); }
@@ -48,6 +28,13 @@ public:
     const sf::Font& font(const std::string& id) const { return *m_fonts.at(id); }
 
 private:
+    std::filesystem::path resolvePath(const std::filesystem::path& path) const;
+    bool tryLoadFont(sf::Font& font, const std::filesystem::path& path) const;
+    std::vector<std::filesystem::path> fontFallbackCandidates() const;
+    void generatePlaceholderTexture(sf::Texture& texture) const;
+    void generateSilentSound(sf::SoundBuffer& buffer) const;
+
+    std::filesystem::path m_assetRoot;
     std::map<std::string, std::unique_ptr<sf::Texture>> m_textures;
     std::map<std::string, std::unique_ptr<sf::SoundBuffer>> m_sounds;
     std::map<std::string, std::unique_ptr<sf::Font>> m_fonts;

--- a/src/levels/Editor.cpp
+++ b/src/levels/Editor.cpp
@@ -46,11 +46,10 @@ void LevelEditor::draw(sf::RenderWindow& window) const {
 }
 
 void LevelEditor::exportJson(const std::string& path) const {
-    nlohmann::json level;
-    level["width"] = m_width;
-    level["height"] = m_height;
-    level["tileSize"] = m_tileSize;
-    level["data"] = m_data;
+    const nlohmann::json level{{"width", m_width},
+                               {"height", m_height},
+                               {"tileSize", m_tileSize},
+                               {"data", m_data}};
     std::ofstream file(path);
     file << level.dump(2);
 }


### PR DESCRIPTION
## Summary
- skip reapplying the SFML libc++ patch when it is already present in the populated source tree
- include SFML's Vector3 helpers and rewrite JSON serialization helpers to avoid ambiguous assignments
- guard wave completion checks against missing level data instead of indexing the const wave map

## Testing
- `cmake -S . -B build` *(fails: missing OpenGL headers/libs in the container image)*

------
https://chatgpt.com/codex/tasks/task_e_68cf262f194c8326a23730b455cb6f2b